### PR TITLE
fix(react): allow using `enabled` when using `useQuery().promise`

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1249,8 +1249,6 @@ describe('queryObserver', () => {
       results.push(result)
     })
 
-    await sleep(1)
-
     observer.setOptions({ queryKey: key, queryFn: () => 'data', enabled: true })
 
 

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -11,6 +11,7 @@ import { waitFor } from '@testing-library/dom'
 import { QueryObserver, focusManager } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'
+import { pendingThenable } from '../thenable'
 
 describe('queryObserver', () => {
   let queryClient: QueryClient
@@ -1243,18 +1244,23 @@ describe('queryObserver', () => {
       queryFn: () => 'data',
     })
     const results: Array<QueryObserverResult> = []
+
+    const success = pendingThenable<void>()
     
 
     const unsubscribe = observer.subscribe((result) => {
+      
       results.push(result)
+
+      if (result.status === 'success') {
+        success.resolve()
+      }
     })
 
     observer.setOptions({ queryKey: key, queryFn: () => 'data', enabled: true })
 
 
-    await waitFor(() => {
-      expect(results.at(-1)?.status).toBe('success')
-    })
+    await success
     
     unsubscribe()
 

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1233,4 +1233,35 @@ describe('queryObserver', () => {
 
     unsubscribe()
   })
+
+  test('switching enabled state should reuse the same promise', async () => {
+    const key = queryKey()
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      enabled: false,
+      queryFn: () => 'data',
+    })
+    const results: Array<QueryObserverResult> = []
+    
+
+    const unsubscribe = observer.subscribe((result) => {
+      results.push(result)
+    })
+
+    await sleep(1)
+
+    observer.setOptions({ queryKey: key, queryFn: () => 'data', enabled: true })
+
+
+    await waitFor(() => {
+      expect(results.at(-1)?.status).toBe('success')
+    })
+    
+    unsubscribe()
+
+    
+    const promises = new Set(results.map((result) => result.promise))
+    expect(promises.size).toBe(1)
+  })
 })

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1246,10 +1246,8 @@ describe('queryObserver', () => {
     const results: Array<QueryObserverResult> = []
 
     const success = pendingThenable<void>()
-    
 
     const unsubscribe = observer.subscribe((result) => {
-      
       results.push(result)
 
       if (result.status === 'success') {
@@ -1257,18 +1255,16 @@ describe('queryObserver', () => {
       }
     })
 
-    observer.setOptions({ 
-      queryKey: key, 
-      queryFn: () => 'data', 
-      enabled: true 
+    observer.setOptions({
+      queryKey: key,
+      queryFn: () => 'data',
+      enabled: true,
     })
 
-
     await success
-    
+
     unsubscribe()
 
-    
     const promises = new Set(results.map((result) => result.promise))
     expect(promises.size).toBe(1)
   })

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1257,7 +1257,11 @@ describe('queryObserver', () => {
       }
     })
 
-    observer.setOptions({ queryKey: key, queryFn: () => 'data', enabled: true })
+    observer.setOptions({ 
+      queryKey: key, 
+      queryFn: () => 'data', 
+      enabled: true 
+    })
 
 
     await success

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/dom'
 import {
   afterEach,
   beforeEach,
@@ -7,11 +8,10 @@ import {
   test,
   vi,
 } from 'vitest'
-import { waitFor } from '@testing-library/dom'
 import { QueryObserver, focusManager } from '..'
+import { pendingThenable } from '../thenable'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'
-import { pendingThenable } from '../thenable'
 
 describe('queryObserver', () => {
   let queryClient: QueryClient

--- a/packages/react-query/src/__tests__/useQuery.promise.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.promise.test.tsx
@@ -1377,4 +1377,75 @@ describe('useQuery().promise', () => {
         .observers.length,
     ).toBe(2)
   })
+
+  it('should handle enabled state changes with suspense', async () => {
+    const key = queryKey()
+    const renderStream = createRenderStream({ snapshotDOM: true })
+    const queryFn = vi.fn(async () => {
+      await sleep(1)
+      return 'test'
+    })
+
+    function MyComponent(props: { enabled: boolean }) {
+      useTrackRenders()
+      const query = useQuery({
+        queryKey: key,
+        queryFn,
+        enabled: props.enabled,
+        staleTime: Infinity,
+      })
+
+      const data = React.use(query.promise)
+      return <>{data}</>
+    }
+
+    function Loading() {
+      useTrackRenders()
+      return <>loading..</>
+    }
+
+    function Page() {
+      useTrackRenders()
+      const enabledState = React.useState(false)
+      const enabled = enabledState[0]
+      const setEnabled = enabledState[1]
+
+      return (
+        <div>
+          <button onClick={() => setEnabled(true)}>enable</button>
+          <React.Suspense fallback={<Loading />}>
+            <MyComponent enabled={enabled} />
+          </React.Suspense>
+        </div>
+      )
+    }
+
+    const rendered = await renderStream.render(
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>,
+    )
+
+    {
+      const result = await renderStream.takeRender()
+      result.withinDOM().getByText('loading..')
+    }
+
+    expect(queryFn).toHaveBeenCalledTimes(0)
+    rendered.getByText('enable').click()
+
+    {
+      const result = await renderStream.takeRender()
+      result.withinDOM().getByText('loading..')
+    }
+
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    {
+      const result = await renderStream.takeRender()
+      result.withinDOM().getByText('test')
+    }
+
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/react-query/src/__tests__/useQuery.promise.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.promise.test.tsx
@@ -1387,7 +1387,6 @@ describe('useQuery().promise', () => {
     })
 
     function MyComponent(props: { enabled: boolean }) {
-      useTrackRenders()
       const query = useQuery({
         queryKey: key,
         queryFn,
@@ -1400,12 +1399,10 @@ describe('useQuery().promise', () => {
     }
 
     function Loading() {
-      useTrackRenders()
       return <>loading..</>
     }
 
     function Page() {
-      useTrackRenders()
       const enabledState = React.useState(false)
       const enabled = enabledState[0]
       const setEnabled = enabledState[1]

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -80,7 +80,6 @@ export function useBaseQuery<
       ),
   )
 
-  
   const result = observer.getOptimisticResult(defaultedOptions)
 
   React.useSyncExternalStore(

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -154,6 +154,7 @@ export function useBaseQuery<
     !isServer &&
     willFetch(result, isRestoring)
   ) {
+    // This fetching in the render should likely be done as part of the getOptimisticResult() considering https://github.com/TanStack/query/issues/8507
     const cacheEntryState = cacheEntry?.state
 
     const shouldFetch =
@@ -162,7 +163,6 @@ export function useBaseQuery<
         cacheEntryState.status === 'pending' &&
         cacheEntryState.fetchStatus === 'idle')
 
-    console.log({ shouldFetch })
     const promise = shouldFetch
       ? // Fetch immediately on render in order to ensure `.promise` is resolved even if the component is unmounted
         fetchOptimistic(defaultedOptions, observer, errorResetBoundary)

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -129,7 +129,6 @@ export function useBaseQuery<
         >(defaultedOptions.queryHash),
     })
   ) {
-    console.log('throwing error')
     throw result.error
   }
 
@@ -138,30 +137,19 @@ export function useBaseQuery<
     result,
   )
 
-  console.log(
-    'prefetchInRender',
-    defaultedOptions.experimental_prefetchInRender,
-    {
-      willFetch: willFetch(result, isRestoring),
-      isRestoring: isRestoring,
-      isLoading: result.isLoading,
-      isFetching: result.isFetching,
-      isServer: isServer,
-    },
-  )
   if (
     defaultedOptions.experimental_prefetchInRender &&
     !isServer &&
     willFetch(result, isRestoring)
   ) {
     // This fetching in the render should likely be done as part of the getOptimisticResult() considering https://github.com/TanStack/query/issues/8507
-    const cacheEntryState = cacheEntry?.state
+    const state = cacheEntry?.state
 
     const shouldFetch =
-      !cacheEntryState ||
-      (cacheEntryState.data === undefined &&
-        cacheEntryState.status === 'pending' &&
-        cacheEntryState.fetchStatus === 'idle')
+      !state ||
+      (state.data === undefined &&
+        state.status === 'pending' &&
+        state.fetchStatus === 'idle')
 
     const promise = shouldFetch
       ? // Fetch immediately on render in order to ensure `.promise` is resolved even if the component is unmounted


### PR DESCRIPTION
Closes #8499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify promise reuse when toggling query enabled state and to ensure correct suspense behavior with dynamic enabled state changes.
- **Refactor**
  - Enhanced data fetching logic with refined state checks for more accurate fetch triggering during render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->